### PR TITLE
change behavior of content width boolean

### DIFF
--- a/src/components/Ui/Infobox.vue
+++ b/src/components/Ui/Infobox.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="w-full max-w-2xl p-8 bg-gray-100">
+    <div class="w-full max-w-4xl p-8 bg-gray-100">
         <div
             v-if="title"
             v-html="title"

--- a/src/modules/content/AccordionSection.vue
+++ b/src/modules/content/AccordionSection.vue
@@ -1,9 +1,9 @@
 <template>
-    <section
-        class="container flex my-16"
-        :class="{ 'justify-center': content.centered }"
-    >
-        <div class="w-full max-w-4xl">
+    <section class="container flex justify-center my-16">
+        <div
+            class="w-full max-w-4xl"
+            :class="{ '!max-w-full': content.content_wide }"
+        >
             <h2 v-if="content.headline">
                 {{ content.headline }}
             </h2>

--- a/src/modules/content/CTASection.vue
+++ b/src/modules/content/CTASection.vue
@@ -1,9 +1,9 @@
 <template>
-    <div
-        class="container flex py-10"
-        :class="{ 'justify-center': content.centered }"
-    >
-        <div class="w-full max-w-4xl">
+    <div class="container flex justify-center py-10">
+        <div
+            class="w-full max-w-4xl"
+            :class="{ '!max-w-full': content.content_wide }"
+        >
             <CTA :link="content.link" :veryImportant="content.important" />
         </div>
     </div>

--- a/src/modules/content/H2Section.vue
+++ b/src/modules/content/H2Section.vue
@@ -1,9 +1,9 @@
 <template>
-    <div
-        class="container flex my-10"
-        :class="{ 'justify-center': content.centered }"
-    >
-        <div class="w-full max-w-4xl">
+    <div class="container flex justify-center my-10">
+        <div
+            class="w-full max-w-4xl"
+            :class="{ '!max-w-full': content.content_wide }"
+        >
             <h2 class="w-full">{{ content.text }}</h2>
         </div>
     </div>

--- a/src/modules/content/ImageSmallSection.vue
+++ b/src/modules/content/ImageSmallSection.vue
@@ -1,9 +1,10 @@
 <template>
-    <div class="container flex" :class="{ 'justify-center': content.centered }">
+    <div class="container flex justify-center">
         <Image
             :image="content.image"
             v-if="content.image"
-            class="w-full my-10 md:max-w-4xl"
+            class="w-full max-w-4xl my-10"
+            :class="{ 'md:!max-w-full': content.content_wide }"
         />
     </div>
 </template>

--- a/src/modules/content/InfoboxSection.vue
+++ b/src/modules/content/InfoboxSection.vue
@@ -1,8 +1,5 @@
 <template>
-    <div
-        class="container flex my-16"
-        :class="{ 'justify-center': content.centered }"
-    >
+    <div class="container flex justify-center my-16">
         <div class="flex justify-center w-full max-w-4xl">
             <Infobox
                 :title="content.title"

--- a/src/modules/content/TextFullSection.vue
+++ b/src/modules/content/TextFullSection.vue
@@ -1,8 +1,5 @@
 <template>
-    <div
-        class="container flex my-16"
-        :class="{ 'justify-center': content.centered }"
-    >
+    <div class="container flex justify-center my-16">
         <div class="w-full max-w-4xl">
             <div v-html="content.text"></div>
         </div>

--- a/src/modules/content/TextImageSection.vue
+++ b/src/modules/content/TextImageSection.vue
@@ -1,9 +1,9 @@
 <template>
-    <div
-        class="container flex my-16"
-        :class="{ 'justify-center': content.centered }"
-    >
-        <div class="grid max-w-4xl grid-cols-12 gap-10">
+    <div class="container flex justify-center my-16">
+        <div
+            class="grid max-w-4xl grid-cols-12 gap-10"
+            :class="{ '!max-w-full': content.content_wide }"
+        >
             <div class="col-span-6">
                 <div class="prose" v-html="content.text"></div>
                 <ButtonPrimary

--- a/src/modules/content/VideoEmbedSection.vue
+++ b/src/modules/content/VideoEmbedSection.vue
@@ -1,9 +1,9 @@
 <template>
-    <div
-        class="container flex my-16"
-        :class="{ 'justify-center': content.centered }"
-    >
-        <div class="w-full max-w-4xl">
+    <div class="container flex justify-center my-16">
+        <div
+            class="w-full max-w-4xl"
+            :class="{ '!max-w-full': content.content_wide }"
+        >
             <div style="padding: 56% 0 0 0; position: relative">
                 <iframe
                     :src="

--- a/src/types/content.ts
+++ b/src/types/content.ts
@@ -22,7 +22,7 @@ export type ContentSections = (
 // TextFull
 export interface TextFull {
     text: string;
-    centered: boolean;
+    content_wide: boolean;
 }
 export type TextFullContentSection = ContentSection<TextFull>;
 
@@ -31,7 +31,7 @@ export interface TextImage {
     text: string;
     image: Image;
     link: Link;
-    centered: boolean;
+    content_wide: boolean;
 }
 export type TextImageContentSection = ContentSection<TextImage>;
 
@@ -39,21 +39,21 @@ export type TextImageContentSection = ContentSection<TextImage>;
 export interface CTA {
     important: boolean;
     link?: Link;
-    centered: boolean;
+    content_wide: boolean;
 }
 export type CTAContentSection = ContentSection<CTA>;
 
 // Video Embed
 export interface VideoEmbed {
     id: string;
-    centered: boolean;
+    content_wide: boolean;
 }
 export type VideoEmbedContentSection = ContentSection<VideoEmbed>;
 
 // Image
 export interface ImageSmall {
     image: Image;
-    centered: boolean;
+    content_wide: boolean;
 }
 export type ImageSmallContentSection = ContentSection<ImageSmall>;
 
@@ -68,7 +68,7 @@ export interface Infobox {
     title: string;
     text: string;
     link: Link;
-    centered: boolean;
+    content_wide: boolean;
 }
 export type InfoboxContentSection = ContentSection<Infobox>;
 
@@ -103,7 +103,7 @@ export type CardsContentSection = ContentSection<Cards>;
 export interface Accordion {
     headline: string;
     items: AccordionItem[];
-    centered: boolean;
+    content_wide: boolean;
 }
 export type AccordionContentSection = ContentSection<Accordion>;
 


### PR DESCRIPTION
This PR adapts to the changes of [this PR](https://github.com/macramejs/admin-vue3/pull/9) where the width switch on content modules leads to the modules being spread across the whole container width.